### PR TITLE
Change shebang to allow other python envs

### DIFF
--- a/src/alignmentstats.py
+++ b/src/alignmentstats.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 import os;
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__));

--- a/src/apply-consensus.py
+++ b/src/apply-consensus.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 # Copyright Ivan Sovic, 2015. www.sovic.org
 #

--- a/src/consensus.py
+++ b/src/consensus.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 # Copyright Ivan Sovic, 2015. www.sovic.org
 #

--- a/src/count_mapped_reads.py
+++ b/src/count_mapped_reads.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 import os;
 import sys;

--- a/src/errorrates.py
+++ b/src/errorrates.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 # Copyright Ivan Sovic, 2015. www.sovic.org
 # 

--- a/src/fastqfilter.py
+++ b/src/fastqfilter.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 # Copyright Ivan Sovic, 2015. www.sovic.org
 #

--- a/src/fastqparser.py
+++ b/src/fastqparser.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 # Script written by Ivan Sovic.
 # Copyright Ivan Sovic, 2014. All rights reserved.

--- a/src/samfilter.py
+++ b/src/samfilter.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 import re;
 import os;

--- a/src/svconsensus.py
+++ b/src/svconsensus.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 # Copyright Ivan Sovic, 2015. www.sovic.org
 #

--- a/src/utility_sam.py
+++ b/src/utility_sam.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 # Copyright Ivan Sovic, 2015. www.sovic.org
 #

--- a/src/vcffilter.py
+++ b/src/vcffilter.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 import re;
 import os;

--- a/src/venn_of_sams.py
+++ b/src/venn_of_sams.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 
 # Written by Ivan Sovic, March 2015.
 #


### PR DESCRIPTION
I am also  failing to run the racon example script in my anaconda environment (Similar to isovic/racon#3).  Changing the shebang in this submodule would fix the issue. 
